### PR TITLE
Add MDR Quagga and wireshark-gtk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,17 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -qq && \
     apt-get install -y openbox obconf git x11vnc xvfb  wget python unzip \
-        bridge-utils ebtables iproute2 iproute2 iproute libev4 quagga \
+        bridge-utils ebtables iproute2 iproute2 iproute libev4 libreadline6 \
         libtk-img tk8.5 dirmngr net-tools tcpdump \
-        feh tint2 python-numpy && \
+        feh tint2 python-numpy logrotate && \
         rm -rf /var/lib/apt/*
+
+
+# If we want the MDR MANET need to use the navy package
+RUN wget https://downloads.pf.itd.nrl.navy.mil/ospf-manet/quagga-0.99.21mr2.2/quagga-mr_0.99.21mr2.2_amd64.deb && \
+    dpkg -i quagga-mr_0.99.21mr2.2_amd64.deb && \
+    rm quagga-mr_0.99.21mr2.2_amd64.deb
+
 
 RUN mkdir -p ~/.vnc
 
@@ -22,25 +29,32 @@ RUN cd /root && git clone https://github.com/kanaka/noVNC.git && \
 
 RUN echo "deb http://eriberto.pro.br/core/ stretch main\ndeb-src http://eriberto.pro.br/core/ stretch main" >> /etc/apt/sources.list.d/core.list && \
     apt-key adv --keyserver pgp.surfnet.nl --recv-keys 04ebe9ef && \
-    apt-get -q update && apt-get -q -y install \
-        core-network tshark \
+    apt-get -q update && apt-get -q -y install --no-install-recommends \
+        core-network core-network-daemon && apt-get -q -y install tshark \
         net-tools rox-filer \
-        quagga xorp bird openssh-client openssh-server isc-dhcp-server vsftpd apache2 tcpdump \
-        radvd at ucarp openvpn ipsec-tools racoon traceroute mgen tshark \
+        xorp bird openssh-client openssh-server isc-dhcp-server vsftpd apache2 tcpdump \
+        radvd at ucarp openvpn ipsec-tools racoon traceroute mgen wireshark-gtk \
         supervisor && \
         rm -rf /var/lib/apt/*
 
+# We have used wireshark-gtk as that has the least dependencies but CORE expects wireshark
+RUN ln -s /usr/bin/wireshark-gtk /usr/bin/wireshark
+
+# If we want the MDR MANET need to use the navy package
+# RUN wget https://downloads.pf.itd.nrl.navy.mil/ospf-manet/quagga-0.99.21mr2.2/quagga-mr_0.99.21mr2.2_amd64.deb && \
+#     dpkg -i quagga-mr_0.99.21mr2.2_amd64.deb && \
+#     rm quagga-mr_0.99.21mr2.2_amd64.deb
 
 RUN cd /root/noVNC && ln -sf vnc.html index.html
 
 # Really necessary if root?
-RUN setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' /usr/bin/dumpcap
+# RUN setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' /usr/bin/dumpcap
 ADD bg/ /root/
 ADD ./config/ /root/.config/
 ADD etc/supervisor/conf.d /etc/supervisor/conf.d
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-ADD extra /extra
+# ADD extra /extra
 VOLUME /root/shared
 # noVNC
 EXPOSE 8080


### PR DESCRIPTION
Added the MDR version of Quagga so that MANET can be used. Added GTK version of wireshark.
The setcap thing failed on build for me so I have removed it. Wireshark works okay but gives warning as it runs as root.
The extra was failing I guess because the blank directory was not cloned in the repo. I have just commented out.